### PR TITLE
[feat] add an entry for ADC0 in RT-Thread Studio Settings

### DIFF
--- a/projects/project_0/board/Kconfig
+++ b/projects/project_0/board/Kconfig
@@ -148,6 +148,16 @@ menu "Hardware Drivers Config"
                 endif
             endif
 
+        menuconfig BSP_USING_ADC
+            bool "Enable ADC"
+            default n
+            select RT_USING_ADC
+            if BSP_USING_ADC
+                config BSP_USING_ADC0
+                    bool "Enable ADC0"
+                    default n
+            endif
+
         menuconfig BSP_USING_FS
             bool "Enable filesystem"
             default n


### PR DESCRIPTION
This solves a problem that you cannot find ADC && ADC0 options in RT-Thread Studio Settings  when you create a project with RT-Thread Studio by default according to the [document ](https://docs.qq.com/doc/DQmVYUEN1dHVyd0hi?_t=1699797902805&u=3966a00c681449d7bed3362d4e91d48c) chapter 5.